### PR TITLE
Fix spawn aria2c ENOENT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+name: build
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: build and release electron app
+    runs-on: ${{ matrix.os }}
+
+  strategy:
+    fail-fast: false
+    matrix:
+      os: [windows-latest, macos-latest, ubuntu-latest]
+
+  steps:
+    - name: Check out git repository
+      uses: actions/checkout@v3
+    
+    - name: Install Node.js
+      uses: actions/setup-node@v3
+    
+    - name: Install Yarn
+      run: npm install -g yarn
+    
+    - name: Install Dependencies
+      run: yarn install
+    
+    - name: Build Electron App
+      run: yarn run build
+      env:
+        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+
+    - name: Cleanup Artifacts for Windows
+      if: matrix.os == 'windwos-latest'
+      run: |
+        npx rimraf "release/!(*.exe)"
+
+    - name: Cleanup Artifacts for MacOS
+      if: matrix.os == 'macos-latest'
+      run: |
+        npx rimraf "release/!(*.dmg)"
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.os }}
+        path: release
+
+    - name: Release
+      uses: softprops/action-gh-release@v0.1.15
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: "release/**"
+      env:
+        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}    
+    
+
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,53 +9,52 @@ jobs:
   release:
     name: build and release electron app
     runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
 
-  strategy:
-    fail-fast: false
-    matrix:
-      os: [windows-latest, macos-latest, ubuntu-latest]
+    steps:
+      - name: Check out git repository
+        uses: actions/checkout@v3
+      
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+      
+      - name: Install Yarn
+        run: npm install -g yarn
+      
+      - name: Install Dependencies
+        run: yarn install
+      
+      - name: Build Electron App
+        run: yarn run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
-  steps:
-    - name: Check out git repository
-      uses: actions/checkout@v3
-    
-    - name: Install Node.js
-      uses: actions/setup-node@v3
-    
-    - name: Install Yarn
-      run: npm install -g yarn
-    
-    - name: Install Dependencies
-      run: yarn install
-    
-    - name: Build Electron App
-      run: yarn run build
-      env:
-        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      - name: Cleanup Artifacts for Windows
+        if: matrix.os == 'windwos-latest'
+        run: |
+          npx rimraf "release/!(*.exe)"
 
-    - name: Cleanup Artifacts for Windows
-      if: matrix.os == 'windwos-latest'
-      run: |
-        npx rimraf "release/!(*.exe)"
+      - name: Cleanup Artifacts for MacOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          npx rimraf "release/!(*.dmg)"
 
-    - name: Cleanup Artifacts for MacOS
-      if: matrix.os == 'macos-latest'
-      run: |
-        npx rimraf "release/!(*.dmg)"
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }}
+          path: release
 
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: ${{ matrix.os }}
-        path: release
-
-    - name: Release
-      uses: softprops/action-gh-release@v0.1.15
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: "release/**"
-      env:
-        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}    
+      - name: Release
+        uses: softprops/action-gh-release@v0.1.15
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: "release/**"
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}    
     
 
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -527,14 +527,15 @@ async function creatAria() {
     }
 
     process.chdir(basePath)
-    const options:SpawnOptions = { stdio: 'ignore', cwd: basePath }
+    const options:SpawnOptions = { stdio: 'ignore', cwd: basePath, shell: true }
     const port = await portIsOccupied(16800)
     const subprocess = spawn(
       ariaPath,
       [
         '--stop-with-process=' + process.pid,
         '-D',
-        '--conf-path=../aria2.conf'
+        '--conf-path=' + confPath,
+        '--listen-port=' + port,
       ],
       options
     )

--- a/electron/main/window.ts
+++ b/electron/main/window.ts
@@ -168,50 +168,50 @@ const debounceResize = (fn: any, wait: number) => {
 
 export function createTray() {
   
-  const trayMenuTemplate = [
-    {
-      label: '显示主界面',
-      click: function () {
-        if (AppWindow.mainWindow && AppWindow.mainWindow.isDestroyed() == false) {
-          if (AppWindow.mainWindow.isMinimized()) AppWindow.mainWindow.restore()
-          AppWindow.mainWindow.show()
-          AppWindow.mainWindow.focus()
-        } else {
-          createMainWindow()
-        }
-      }
-    },
-    {
-      label: '彻底退出并停止下载',
-      click: function () {
-        if (AppWindow.mainWindow) {
-          AppWindow.mainWindow.destroy()
-          AppWindow.mainWindow = undefined
-        }
-        app.quit()
-      }
-    }
-  ]
+  // const trayMenuTemplate = [
+  //   {
+  //     label: '显示主界面',
+  //     click: function () {
+  //       if (AppWindow.mainWindow && AppWindow.mainWindow.isDestroyed() == false) {
+  //         if (AppWindow.mainWindow.isMinimized()) AppWindow.mainWindow.restore()
+  //         AppWindow.mainWindow.show()
+  //         AppWindow.mainWindow.focus()
+  //       } else {
+  //         createMainWindow()
+  //       }
+  //     }
+  //   },
+  //   {
+  //     label: '彻底退出并停止下载',
+  //     click: function () {
+  //       if (AppWindow.mainWindow) {
+  //         AppWindow.mainWindow.destroy()
+  //         AppWindow.mainWindow = undefined
+  //       }
+  //       app.quit()
+  //     }
+  //   }
+  // ]
 
   
-  const icon = getResourcesPath('app.ico')
-  AppWindow.appTray = new Tray(icon)
+  // const icon = getResourcesPath('app.ico')
+  // AppWindow.appTray = new Tray(icon)
   
-  const contextMenu = Menu.buildFromTemplate(trayMenuTemplate)
+  // const contextMenu = Menu.buildFromTemplate(trayMenuTemplate)
   
-  AppWindow.appTray.setToolTip('阿里云盘小白羊版')
+  // AppWindow.appTray.setToolTip('阿里云盘小白羊版')
   
-  AppWindow.appTray.setContextMenu(contextMenu)
+  // AppWindow.appTray.setContextMenu(contextMenu)
 
-  AppWindow.appTray.on('click', () => {
-    if (AppWindow.mainWindow && AppWindow.mainWindow.isDestroyed() == false) {
-      if (AppWindow.mainWindow.isMinimized()) AppWindow.mainWindow.restore()
-      AppWindow.mainWindow.show()
-      AppWindow.mainWindow.focus()
-    } else {
-      createMainWindow()
-    }
-  })
+  // AppWindow.appTray.on('click', () => {
+  //   if (AppWindow.mainWindow && AppWindow.mainWindow.isDestroyed() == false) {
+  //     if (AppWindow.mainWindow.isMinimized()) AppWindow.mainWindow.restore()
+  //     AppWindow.mainWindow.show()
+  //     AppWindow.mainWindow.focus()
+  //   } else {
+  //     createMainWindow()
+  //   }
+  // })
 }
 
 export function creatUpload() {


### PR DESCRIPTION
# Environment

macOS Ventura 13.1, Apple M1

# The Bug

Opening the packaged APP directly in the production environment will result in the following error：
```
错误信息:spawn aria2c ENOENT
Error: spawn aria2c ENOENT
at ChildProcess._handle.onexit (node:internal/child_process:283:19)
at onErrorNT (node:internal/child_process:478:16)
at process.processTicksAndRejections (node:internal/process/task_queues:83:21)
```

If you click OK, it will automatically exit.

However, this error will not appear in the development environment or in the production environment using the shell.

# How to Fix

It just need to add `{ shell: true }` to the SpawnOptions.

# More

Fixed the logical problem of listen port.