### PR TITLE
fix: linux command spawn doesn't need the `open` wrapper

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -353,7 +353,12 @@ ipcMain.on('WebSpawnSync', (event, data) => {
       event.returnValue = { error: '找不到文件' + data.command }
       ShowError('找不到文件', data.command)
     } else {
-      const command = is.windows() ? `${data.command}` : `open -a ${data.command} ${data.command.includes('mpv.app') ? '--args ' : ''}`
+      let command
+      if (is.macOS()) {
+        command = `open -a ${data.command} ${data.command.includes('mpv.app') ? '--args ' : ''}`
+      } else {
+        command = `${data.command}`
+      }
       const subProcess = spawn(command, data.args, options)
       const isRunning = process.kill(subProcess.pid, 0)
       subProcess.unref()


### PR DESCRIPTION
Like windows, linux external video player's spawning does not need macOS's `open` wrapper.