### PR TITLE
Add the Archlinux Pacman into electron-builder target

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -38,7 +38,8 @@
     ],
     "target": [
       { "target": "AppImage", "arch": [  "x64", "arm64", "armv7l" ] },
-      { "target": "deb", "arch": [ "x64",  "arm64", "armv7l" ] }
+      { "target": "deb", "arch": [ "x64",  "arm64", "armv7l" ] },
+      { "target": "pacman", "arch": [ "x64", "arm64" ] }
     ]
   },
   "win": {


### PR DESCRIPTION
Since the pnpm supported to generate the pacman package, I have added the target into the electron-builder.json